### PR TITLE
feat: add GitHub Actions workflow for deploying to Snack

### DIFF
--- a/.github/workflows/deploy-snack.yml
+++ b/.github/workflows/deploy-snack.yml
@@ -1,0 +1,33 @@
+name: Deploy to Snack
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Deploy to Snack
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          SNACK_ID: ${{ secrets.SNACK_ID }}
+        run: |
+          npx -y @expo/snack-content-cli@latest push \
+            --path ./ \
+            --snack-id $SNACK_ID \
+            --expo-token $EXPO_TOKEN \
+            --ignore "**/node_modules/**" \
+            --ignore ".git/**" \
+            --ignore ".github/**"

--- a/app.json
+++ b/app.json
@@ -37,6 +37,12 @@
     ],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "045333cf-9459-4d95-80bb-cfadb6cbb1d8"
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for deploying to Expo Snack and updates the `app.json` configuration to include additional metadata for Expo's EAS (Expo Application Services). Below are the key changes:

### Workflow Automation:
* Added a new GitHub Actions workflow, `.github/workflows/deploy-snack.yml`, to automate deployment to Expo Snack. This includes steps for checking out the code, setting up Node.js, installing dependencies, and deploying using the `@expo/snack-content-cli` tool.

### Configuration Updates:
* Updated `app.json` to include an `extra` field with a `router` object and an `eas` object containing the `projectId` for Expo's EAS configuration.